### PR TITLE
upgrade blockstack.js to 18.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preact-render-spy": "^1.2.1"
   },
   "dependencies": {
-    "blockstack": "^18.1.0",
+    "blockstack": "^18.2.1",
     "bluebird": "^3.5.3",
     "immutability-helper": "^2.8.1",
     "preact": "^8.2.6",


### PR DESCRIPTION
Hey there!

We recently upgraded blockstack.js to gracefully handle failures in the case of Gaia tokens being invalidated. With this upgrade, if Gaia tokens are ever invalidated, `blockstack.js` will automatically generate a new token and retry a write to Gaia.

Without this change, all writes will fail until the user logs out and back in.

I think this upgrade is rather important, so that your app can gracefully handle Gaia authentication errors due to token invalidations.

Hope all is well,

Hank